### PR TITLE
Disable broken metrics plugins to clean up the SVG

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -17,7 +17,7 @@ jobs:
           template: classic
           base: header, activity, community, repositories
           config_timezone: Asia/Riyadh
-          plugin_traffic: yes
+          plugin_traffic: no
           plugin_topics: yes
           plugin_topics_limit: 0
           plugin_topics_mode: icons
@@ -33,25 +33,25 @@ jobs:
           plugin_lines_sections: repositories, history
           plugin_lines_repositories_limit: 4
           plugin_lines_history_limit: 1          
-          plugin_languages: yes
+          plugin_languages: no
           plugin_languages_sections: most-used
           plugin_languages_details: bytes-size, percentage
           plugin_languages_limit: 8         
           plugin_isocalendar: yes
           plugin_isocalendar_duration: full-year
           plugin_introduction: yes
-          plugin_habits: yes
+          plugin_habits: no
           plugin_habits_facts: no
           plugin_habits_charts: yes
           plugin_followup: yes
           plugin_followup_archived: no      
           plugin_calendar: yes
           plugin_calendar_limit: 2          
-          plugin_activity: yes
+          plugin_activity: no
           plugin_activity_limit: 1
           plugin_activity_days: 0
           plugin_activity_filter: issue, pr, release, fork, review, ref/create          
-          plugin_achievements: yes
+          plugin_achievements: no
           plugin_achievements_only: >-
             polyglot, stargazer, deployer, developer,
             scripter, packager, explorer, infographile, manager


### PR DESCRIPTION
## Summary
- Disables 5 plugins in `.github/workflows/update-readme.yml` that are responsible for the visible problems in `github-metrics.svg`
- All changes verified by running the workflow on the `claude/metrics-fix` test branch with the real `PP_TOKEN` and inspecting the resulting SVG

## What each disable fixes
| Plugin | Problem on the SVG | Root cause |
|---|---|---|
| `plugin_traffic` | "Insufficient token scopes" line | Traffic API needs push on every repo; org repos fail. No PAT scope can fix this. |
| `plugin_habits` | "Recent coding habits → Unexpected error" | v3.34 bug: `Cannot destructure 'author' of undefined` (`habits/index.mjs:51`) |
| `plugin_activity` | "Recent activity → Unexpected error" | v3.34 bug: `Cannot read properties of undefined (reading 'filter')` (`activity/index.mjs:140`) |
| `plugin_achievements` | "Achievements → Unexpected error" | GraphQL: "Projects (classic) is being deprecated" — GitHub removed the API |
| `plugin_languages` | "0 Languages" with `most-used`; full crash with `recently-used` | v3.34 has the `committer` destructure bug in `languages/analyzer/recent.mjs:70`; `most-used` returns no data |

## Verification
Three test variants run on `claude/metrics-fix`:

| Variant | Languages mode | Result |
|---|---|---|
| 1 | `most-used` | errors gone, but section showed "0 Languages" |
| 2 | `most-used, recently-used` | full workflow crash (committer destructure) |
| 3 (this PR) | `plugin_languages: no` | **fully clean SVG, all error markers absent** |

Final SVG grep on variant 3:
```
Insufficient token scopes  : 0
Unexpected error           : 0
TypeError                  : 0
GraphqlResponseError       : 0
```

## Trade-off
Five sections are removed from the rendered SVG: traffic, languages, recent habits, recent activity, achievements. Everything else (header, activity stats, community stats, repositories, isocalendar, contributions calendar, lines of code, stargazers, featured repository, topics, recently starred, follow-ups, introduction) renders cleanly.

## Test plan
- [x] Workflow run on test branch succeeded ([run 25424466689](https://github.com/assirims/assirims/actions/runs/25424466689))
- [x] SVG verified free of `Insufficient token scopes`, `Unexpected error`, `TypeError`, `GraphqlResponseError`
- [x] All preserved sections still present
- [ ] Merge → run on `main` → confirm `github-metrics.svg` renders the same way